### PR TITLE
misc Schedule_R.thy corres lemmas

### DIFF
--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -3865,6 +3865,217 @@ lemma awaken_corres:
   apply (fastforce intro!: awaken_terminates)
   done
 
+(* FIXME: Many of these can be moved higher? *)
+lemma getReprogramTimer_corres:
+  "corres (=) \<top> \<top> (gets reprogram_timer) getReprogramTimer"
+  by (clarsimp simp: getReprogramTimer_def state_relation_def)
+
+lemma setDomainTime_corres:
+  "dt = dt' \<Longrightarrow>
+  corres dc \<top> \<top> (modify (domain_time_update (\<lambda>_. dt))) (setDomainTime dt')"
+  apply (clarsimp simp: setDomainTime_def, rule corres_modify)
+  by (clarsimp simp: state_relation_def swp_def)
+
+lemma setConsumedTime_corres:
+  "ct = ct' \<Longrightarrow>
+  corres dc \<top> \<top> (modify (consumed_time_update (\<lambda>_. ct))) (setConsumedTime ct')"
+  apply (clarsimp simp: setConsumedTime_def, rule corres_modify)
+  by (clarsimp simp: state_relation_def swp_def)
+
+lemma setCurSc_corres:
+  "sc = sc' \<Longrightarrow>
+   corres dc \<top> \<top> (modify (cur_sc_update (\<lambda>_. sc))) (setCurSc sc')"
+  apply (clarsimp simp: setCurSc_def, rule corres_modify)
+  by (clarsimp simp: state_relation_def swp_def)
+
+lemma machine_op_lift_corres_trivial:
+  "f = f' \<Longrightarrow> corres_underlying Id False True dc \<top> \<top> (machine_op_lift f) (machine_op_lift f')"
+  unfolding setDeadline_def
+  apply (clarsimp simp: machine_op_lift_def machine_rest_lift_def)
+  apply (rule corres_guard_imp)
+    apply (rule corres_split [OF corres_gets_trivial], simp)
+      apply (rule corres_split_eqr [OF _ corres_select_f])
+          apply (clarsimp, rule corres_modify, simp)
+         apply (clarsimp simp: ignore_failure_def)
+        apply (clarsimp simp: ignore_failure_def)
+       apply wpsimp+
+  done
+
+lemma setDeadline_corres:
+  "dl = dl' \<Longrightarrow> corres_underlying Id False True dc \<top> \<top> (setDeadline dl) (setDeadline dl')"
+  unfolding setDeadline_def
+  by (rule machine_op_lift_corres_trivial, simp)
+
+(* Most sched contexts should satisfy these conditions. The lemma below (standard_sc_common_usage)
+   illustrates a common situation where these conditions hold *)
+abbreviation standard_sc where
+  "standard_sc sc \<equiv> scRefillMax sc \<le> length (scRefills sc) \<and> scRefillHead sc < scRefillMax sc \<and>
+                    scRefillCount sc \<le> scRefillMax sc \<and> 0 < scRefillCount sc"
+
+lemma standard_sc_common_usage:
+  "\<exists>n. sc_relation sc n sc' \<Longrightarrow> sc_active sc \<Longrightarrow> sc_valid_refills sc \<Longrightarrow> valid_sched_context' sc' s'
+   \<Longrightarrow> standard_sc sc'"
+  apply (clarsimp simp: sc_valid_refills_def valid_sched_context'_def active_sc_def sc_relation_def)
+  apply (cases "scRefillCount sc' = 0"; simp)
+  apply (subgoal_tac "sc_refills sc = []")
+   apply (clarsimp split: if_splits simp: rr_valid_refills_def sp_valid_refills_def)
+  apply (clarsimp simp: refills_map_def)
+  done
+
+lemma refillSingle_equiv:
+  "standard_sc sca \<Longrightarrow>
+   (length (refills_map (scRefillHead sca) (scRefillCount sca) (scRefillMax sca) (scRefills sca)) = Suc 0)
+    = (scRefillHead sca = refillTailIndex sca)"
+  apply (clarsimp simp: valid_sched_context'_def refillTailIndex_def refills_map_def)
+  apply (case_tac "scRefillCount sca = Suc 0"; simp)
+  apply (auto simp: Let_def)
+  done
+
+lemma refillSingle_corres:
+  "scp = scp' \<Longrightarrow>
+   corres (=) (sc_at scp) (sc_at' scp' and (\<lambda>s. obj_at' standard_sc scp' s))
+     (refill_single scp) 
+     (refillSingle scp')"
+  unfolding refill_single_def refillSingle_def
+  apply (simp add: refill_size_def get_refills_def)
+  apply (rule stronger_corres_guard_imp)
+    apply (rule_tac R'="\<lambda>sc s. standard_sc sc" and R="\<lambda>_ _ . True" in corres_split)
+       apply (rule get_sc_corres)
+      apply (clarsimp simp: sc_relation_def)
+      apply (rule refillSingle_equiv; simp)
+     apply wpsimp+
+  apply (clarsimp simp: obj_at'_def)
+  done
+
+lemma sc_relation_refill_hd_equiv:
+  "\<exists>n. sc_relation rv n rv' \<Longrightarrow> standard_sc rv' \<Longrightarrow> refill_hd rv = refill_map (refillHd rv')"
+  apply (subgoal_tac " sc_refills rv \<noteq> []")
+   apply (clarsimp simp: sc_relation_def refillHd_def refills_map_def valid_sched_context'_def hd_map hd_wrap_slice refill_map_def)
+  apply (clarsimp simp: sc_relation_def refills_map_def)
+  apply (subgoal_tac "length (wrap_slice (scRefillHead rv') (scRefillCount rv') (scRefillMax rv') (scRefills rv')) = scRefillCount rv'")
+   apply (clarsimp simp: refills_map_def)
+  apply (rule length_wrap_slice; simp)
+  done
+
+lemma pspace_relation_sc_relation:
+  "pspace_relation h h' \<Longrightarrow> 
+   h x = Some (kernel_object.SchedContext sc n) \<Longrightarrow>
+   h' x = Some (KOSchedContext sc') \<Longrightarrow>
+   valid_sched_context_size n \<Longrightarrow>
+   sc_relation sc n sc'"
+  apply (clarsimp simp: pspace_relation_def)
+  apply (drule_tac x=x in bspec, clarsimp)
+  by (clarsimp)
+
+lemma pspace_relation_tcb_relation:
+  "pspace_relation h h' \<Longrightarrow> 
+   h x = Some (kernel_object.TCB tcb) \<Longrightarrow>
+   h' x = Some (KOTCB tcb') \<Longrightarrow>
+   tcb_relation tcb tcb'"
+  apply (clarsimp simp: pspace_relation_def)
+  apply (drule_tac x=x in bspec, clarsimp)
+  by (clarsimp simp: other_obj_relation_def)
+
+(* This is not particularly insightful, it just shortens setNextInterrupt_corres *)
+lemma setNextInterrupt_corres_helper:
+  "\<lbrakk>valid_objs' s'; (s, s') \<in> state_relation; active_sc_tcb_at t s;
+    valid_objs s; active_sc_valid_refills s; pspace_aligned s; pspace_distinct s\<rbrakk>
+    \<Longrightarrow> \<exists>tcb. ko_at' tcb t s' \<and> sc_at' (the (tcbSchedContext tcb)) s' \<and>
+        (\<forall>ko. ko_at' ko (the (tcbSchedContext tcb)) s' \<longrightarrow> standard_sc ko)"
+  apply (subgoal_tac "\<exists>tcb'. ko_at' (tcb'  :: tcb) t s'", clarsimp)
+   apply (clarsimp simp: pred_map_def vs_all_heap_simps)
+   apply (rename_tac tcb' scp tcb sc n)
+   apply (frule pspace_relation_tcb_relation [OF state_relation_pspace_relation], assumption)
+    apply (clarsimp simp: obj_at'_def projectKOs, rule refl)
+   apply (rule_tac x=tcb' in exI, simp)
+   apply (prop_tac "tcbSchedContext tcb' = Some scp", clarsimp simp: tcb_relation_def, simp)
+   apply (subgoal_tac "sc_at' scp s'", clarsimp)
+    apply (frule pspace_relation_sc_relation[OF state_relation_pspace_relation], assumption)
+      apply (clarsimp simp: obj_at'_def projectKOs, rule refl)
+     apply (erule (1) valid_sched_context_size_objsI)
+    apply (rule standard_sc_common_usage, erule exI)
+      apply (clarsimp simp: active_sc_def vs_all_heap_simps pred_map_def is_tcb obj_at_def)
+     apply (subgoal_tac "valid_refills scp s", clarsimp simp: valid_refills_def2 obj_at_def)
+     apply (erule active_sc_valid_refillsE[rotated])
+     apply (clarsimp simp: active_sc_def vs_all_heap_simps pred_map_def is_tcb obj_at_def)
+    apply (frule (1) sc_ko_at_valid_objs_valid_sc', clarsimp, assumption)
+   apply (erule cross_relF [OF _ sc_at'_cross_rel], clarsimp simp: obj_at_def is_sc_obj)
+   apply (erule (1) valid_sched_context_size_objsI)
+  apply (subgoal_tac "tcb_at t s")
+   apply (frule cross_relF [OF _ tcb_at'_cross_rel], clarsimp, assumption)
+   apply (clarsimp simp: obj_at'_def projectKOs)
+  apply (clarsimp simp: obj_at_def vs_all_heap_simps pred_map_def is_tcb)
+  done
+
+lemma setNextInterrupt_corres:
+  "corres dc ((\<lambda>s. active_sc_tcb_at (cur_thread s) s) and valid_release_q and valid_objs
+              and active_sc_valid_refills and pspace_aligned and pspace_distinct) 
+             valid_objs'
+             set_next_interrupt 
+             setNextInterrupt"
+  unfolding setNextInterrupt_def set_next_interrupt_def
+  apply (rule stronger_corres_guard_imp)
+    apply (rule corres_split [OF getCurTime_corres])
+      apply (rule corres_split [OF gct_corres], simp)
+        apply (rule corres_split_eqr [OF _ get_tcb_obj_ref_corres])
+           apply (rule corres_assert_opt_assume_l)
+           apply (rule corres_split [OF get_sc_corres])
+             apply (rule_tac F="standard_sc rv'" in corres_gen_asm2)
+             apply (rule corres_split [OF corres_if])
+                  apply (clarsimp simp: num_domains_def numDomains_def)
+                 apply (rule corres_split [OF domain_time_corres])
+                   apply (simp only: fun_app_def)
+                   apply (rule corres_return_eq_same)
+                   apply (simp add: sc_relation_refill_hd_equiv refill_map_def)
+                  apply wpsimp
+                 apply wpsimp
+                apply (rule corres_return_eq_same)
+                apply (simp add: sc_relation_refill_hd_equiv refill_map_def)
+               apply (rule corres_split [OF getReleaseQueue_corres])
+                 apply (rule corres_split [OF corres_if], simp)
+                     apply (rule corres_return_eq_same, simp)
+                    apply (rule corres_split_eqr)
+                       apply (rule corres_assert_opt_assume_l)
+                       apply (simp)
+                       apply (rule corres_split [OF get_sc_corres])
+                         apply (rule_tac F="standard_sc rv'c" in corres_gen_asm2)
+                         apply (rule corres_return_eq_same)
+                         apply (simp add: sc_relation_refill_hd_equiv refill_map_def)
+                        apply wpsimp
+                       apply wpsimp
+                      apply (simp, rule get_tcb_obj_ref_corres)
+                      apply (clarsimp simp: tcb_relation_def)
+                     apply (wpsimp wp: get_tcb_obj_ref_wp)
+                    apply (wpsimp wp: threadGet_wp)
+                   apply (rule corres_machine_op)
+                   apply (simp only:, rule setDeadline_corres, simp)
+                  apply wpsimp+
+          apply (clarsimp simp: tcb_relation_def)
+         apply (wpsimp wp: get_tcb_obj_ref_wp)
+        apply (wpsimp wp: threadGet_wp)
+       apply wpsimp+
+   apply (subgoal_tac "release_queue s \<noteq> [] \<longrightarrow> active_sc_tcb_at (hd (release_queue s)) s")
+    apply (fastforce simp: cur_tcb_def pred_tcb_at_def vs_all_heap_simps obj_at_def is_sc_obj is_tcb
+                     elim: valid_sched_context_size_objsI)[1]
+   apply (clarsimp simp: valid_release_q_def)
+  apply simp
+  apply (subgoal_tac "(\<exists>tcb. ko_at' tcb (ksCurThread s') s' \<and>
+                    sc_at' (the (tcbSchedContext tcb)) s' \<and>
+                    (\<forall>ko. ko_at' ko (the (tcbSchedContext tcb)) s' \<longrightarrow> standard_sc ko)) \<and> (ksReleaseQueue s' \<noteq> [] \<longrightarrow> (\<exists>tcb. ko_at' tcb (hd (ksReleaseQueue s')) s' \<and>
+                    sc_at' (the (tcbSchedContext tcb)) s' \<and>
+                    (\<forall>ko. ko_at' ko (the (tcbSchedContext tcb)) s' \<longrightarrow> standard_sc ko)))")
+   apply (safe, blast, blast)[1]
+   apply (rule_tac x=tcb in exI, simp, safe, blast)[1]
+  apply (intro conjI; clarsimp)
+   apply (prop_tac "ksCurThread s' = cur_thread s", clarsimp simp: state_relation_def, simp)
+   apply (rule setNextInterrupt_corres_helper; simp)
+  apply (subgoal_tac "(ksReleaseQueue s') = release_queue s", simp)
+   apply (subgoal_tac "active_sc_tcb_at (hd (release_queue s)) s")
+    apply (rule setNextInterrupt_corres_helper; simp)
+   apply (clarsimp simp: valid_release_q_def)
+  apply (clarsimp simp: state_relation_def release_queue_relation_def)
+  done
+
 lemma schedule_corres:
   "corres dc (invs and valid_sched and valid_list) invs' (Schedule_A.schedule) ThreadDecls_H.schedule"
   supply tcbSchedEnqueue_invs'[wp del]

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -3934,7 +3934,7 @@ lemma refillSingle_equiv:
 lemma refillSingle_corres:
   "scp = scp' \<Longrightarrow>
    corres (=) (sc_at scp) (sc_at' scp' and (\<lambda>s. obj_at' standard_sc scp' s))
-     (refill_single scp) 
+     (refill_single scp)
      (refillSingle scp')"
   unfolding refill_single_def refillSingle_def
   apply (simp add: refill_size_def get_refills_def)
@@ -3958,7 +3958,7 @@ lemma sc_relation_refill_hd_equiv:
   done
 
 lemma pspace_relation_sc_relation:
-  "pspace_relation h h' \<Longrightarrow> 
+  "pspace_relation h h' \<Longrightarrow>
    h x = Some (kernel_object.SchedContext sc n) \<Longrightarrow>
    h' x = Some (KOSchedContext sc') \<Longrightarrow>
    valid_sched_context_size n \<Longrightarrow>
@@ -3968,7 +3968,7 @@ lemma pspace_relation_sc_relation:
   by (clarsimp)
 
 lemma pspace_relation_tcb_relation:
-  "pspace_relation h h' \<Longrightarrow> 
+  "pspace_relation h h' \<Longrightarrow>
    h x = Some (kernel_object.TCB tcb) \<Longrightarrow>
    h' x = Some (KOTCB tcb') \<Longrightarrow>
    tcb_relation tcb tcb'"
@@ -4009,9 +4009,9 @@ lemma setNextInterrupt_corres_helper:
 
 lemma setNextInterrupt_corres:
   "corres dc ((\<lambda>s. active_sc_tcb_at (cur_thread s) s) and valid_release_q and valid_objs
-              and active_sc_valid_refills and pspace_aligned and pspace_distinct) 
+              and active_sc_valid_refills and pspace_aligned and pspace_distinct)
              valid_objs'
-             set_next_interrupt 
+             set_next_interrupt
              setNextInterrupt"
   unfolding setNextInterrupt_def set_next_interrupt_def
   apply (rule stronger_corres_guard_imp)

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -3146,6 +3146,7 @@ lemma schedule_invs':
   apply (rule_tac hoare_seq_ext, rename_tac t)
    apply (rule_tac Q="invs'" in hoare_weaken_pre)
     apply (rule_tac hoare_seq_ext[OF _ getCurThread_sp])
+    apply (rule_tac hoare_seq_ext[OF _ isSchedulable_sp])
     apply (rule_tac hoare_seq_ext[OF _ getSchedulerAction_sp])
     apply (rule hoare_seq_ext)
      apply (wpsimp wp: switchSchedContext_invs')
@@ -3160,7 +3161,7 @@ lemma schedule_invs':
             apply (wpsimp simp: isHighestPrio_def')
            apply (wpsimp wp: curDomain_wp)
           apply (wpsimp simp: scheduleSwitchThreadFastfail_def)
-         apply (rename_tac tPtr isSchedulable x idleThread targetPrio)
+         apply (rename_tac tPtr x idleThread targetPrio)
          apply (rule_tac Q="\<lambda>_. invs' and st_tcb_at' runnable' tPtr and (\<lambda>s. action = ksSchedulerAction s)
                                 and tcb_in_cur_domain' tPtr" in hoare_strengthen_post[rotated])
           apply (prop_tac "st_tcb_at' runnable' tPtr s \<Longrightarrow> obj_at' (\<lambda>a. activatable' (tcbState a)) tPtr s")
@@ -3169,13 +3170,13 @@ lemma schedule_invs':
            apply (clarsimp simp: all_invs_but_ct_idle_or_in_cur_domain'_def invs'_def valid_state'_def)
           apply fastforce
          apply (wpsimp wp: threadGet_wp hoare_drop_imp hoare_vcg_ex_lift)
-        apply (rename_tac tPtr isSchedulable x idleThread)
+        apply (rename_tac tPtr x idleThread)
         apply (rule_tac Q="\<lambda>_. invs'
                                and st_tcb_at' runnable' tPtr and (\<lambda>s. action = ksSchedulerAction s)
                                and tcb_in_cur_domain' tPtr" in hoare_strengthen_post[rotated])
          apply (subst obj_at_ko_at'_eq[symmetric], simp)
         apply (wpsimp wp: threadGet_wp hoare_drop_imp hoare_vcg_ex_lift)
-       apply (rename_tac tPtr isSchedulable x)
+       apply (rename_tac tPtr x)
        apply (rule_tac Q="\<lambda>_. invs'
                               and st_tcb_at' runnable' tPtr and (\<lambda>s. action = ksSchedulerAction s)
                               and tcb_in_cur_domain' tPtr" in hoare_strengthen_post[rotated])

--- a/spec/haskell/src/SEL4/Kernel/Thread.lhs
+++ b/spec/haskell/src/SEL4/Kernel/Thread.lhs
@@ -341,6 +341,7 @@ has the highest runnable priority in the system on kernel entry (unless idle).
 > schedule = do
 >     awaken
 >     curThread <- getCurThread
+>     isSchedulable <- isSchedulable curThread
 >     action <- getSchedulerAction
 >     case action of
 
@@ -352,12 +353,11 @@ An IPC operation may request that the scheduler switch to a specific thread.
 We check here that the candidate has the highest priority in the system.
 
 >         SwitchToThread candidate -> do
->             isSchedulable <- isSchedulable curThread
 >             when isSchedulable (tcbSchedEnqueue curThread)
 >
 >             idleThread <- getIdleThread
 >             targetPrio <- threadGet tcbPriority candidate
->             curPrio <- if idleThread == curThread then return 0 else threadGet tcbPriority curThread
+>             curPrio <- if (curThread /= idleThread) then (threadGet tcbPriority curThread) else (return 0)
 >             fastfail <- scheduleSwitchThreadFastfail curThread idleThread curPrio targetPrio
 >
 >             curDom <- curDomain
@@ -380,7 +380,6 @@ We check here that the candidate has the highest priority in the system.
 If the current thread is no longer runnable, has used its entire timeslice, an IPC cancellation has potentially woken multiple higher priority threads, or the domain timeslice is exhausted, then we scan the scheduler queues to choose a new thread. In the last case, we switch to the next domain beforehand.
 
 >         ChooseNewThread -> do
->             isSchedulable <- isSchedulable curThread
 >             when isSchedulable $ tcbSchedEnqueue curThread
 >             scheduleChooseNewThread
 >


### PR DESCRIPTION
This is incremental progress towards `schedule_corres`. The main contributions are:
* `setNextInterrupt_corres`
* `getReprogramTimer_corres`
* `setDomainTime_corres`
* `setConsumedTime_corres`
* `setCurSc_corres`
* `machine_op_lift_corres_trivial`
* `refillSingle_corres`

This also introduces `standard_sc` which might be useful, I'd appreciate some feedback on that.
